### PR TITLE
Uniformize view names for `create_mirror*`

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3506,24 +3506,24 @@ auto create_mirror(const Kokkos::View<T, P...>& src,
 template <class T, class... P>
 std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Kokkos::View<T, P...>::HostMirror>
-create_mirror(Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, Impl::ViewCtorProp<>{});
+create_mirror(Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
 template <class T, class... P>
 std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Kokkos::View<T, P...>::HostMirror>
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
-              Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, view_alloc(wi));
+              Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, view_alloc(wi));
 }
 
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Impl::MirrorType<Space, T, P...>::view_type>
-create_mirror(Space const&, Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, view_alloc(typename Space::memory_space{}));
+create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
 }
 
 template <class T, class... P, class... ViewCtorArgs,
@@ -3531,8 +3531,8 @@ template <class T, class... P, class... ViewCtorArgs,
               std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
               Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space>>
 auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-                   Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, arg_prop);
+                   Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, arg_prop);
 }
 
 template <class T, class... P, class... ViewCtorArgs>
@@ -3541,8 +3541,8 @@ std::enable_if_t<
         !Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space,
     typename Kokkos::View<T, P...>::HostMirror>
 create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-              Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, arg_prop);
+              Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, arg_prop);
 }
 
 template <class Space, class T, class... P,
@@ -3550,8 +3550,8 @@ template <class Space, class T, class... P,
 std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Impl::MirrorType<Space, T, P...>::view_type>
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
-              Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, view_alloc(typename Space::memory_space{}, wi));
+              Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}, wi));
 }
 
 namespace Impl {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3551,7 +3551,8 @@ std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Impl::MirrorType<Space, T, P...>::view_type>
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
               Kokkos::View<T, P...> const& src) {
-  return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}, wi));
+  return Impl::create_mirror(src,
+                             view_alloc(typename Space::memory_space{}, wi));
 }
 
 namespace Impl {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3647,8 +3647,8 @@ create_mirror_view(const Kokkos::View<T, P...>& src) {
 
 template <class T, class... P>
 typename Kokkos::View<T, P...>::HostMirror create_mirror_view(
-    Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror_view(v, view_alloc(wi));
+    Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror_view(src, view_alloc(wi));
 }
 
 // FIXME_C++17 Improve SFINAE here.
@@ -3675,15 +3675,15 @@ template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, Space const&,
-    Kokkos::View<T, P...> const& v) {
+    Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(
-      v, view_alloc(typename Space::memory_space{}, wi));
+      src, view_alloc(typename Space::memory_space{}, wi));
 }
 
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
-                        const Kokkos::View<T, P...>& v) {
-  return Impl::create_mirror_view(v, arg_prop);
+                        const Kokkos::View<T, P...>& src) {
+  return Impl::create_mirror_view(src, arg_prop);
 }
 
 template <class... ViewCtorArgs, class T, class... P>


### PR DESCRIPTION
This PR aims to harmonize the name of the input views in `create_mirror` and `create_mirror_views` functions by systematically naming them `src`.

This PR is part of a of a larger effort which aims to fix kokkos/kokkos#6842.