### PR TITLE
Move intelligence to `Impl::create_mirror*`

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3556,70 +3556,40 @@ auto create_mirror_view(const Kokkos::View<T, P...>& src,
 }  // namespace Impl
 
 template <class T, class... P>
-std::enable_if_t<
-    std::is_same<
-        typename Kokkos::View<T, P...>::memory_space,
-        typename Kokkos::View<T, P...>::HostMirror::memory_space>::value &&
-        std::is_same<
-            typename Kokkos::View<T, P...>::data_type,
-            typename Kokkos::View<T, P...>::HostMirror::data_type>::value,
-    typename Kokkos::View<T, P...>::HostMirror>
-create_mirror_view(const Kokkos::View<T, P...>& src) {
+auto create_mirror_view(const Kokkos::View<T, P...>& src) {
   return src;
 }
 
+// without_initializing
 template <class T, class... P>
-std::enable_if_t<
-    !(std::is_same<
-          typename Kokkos::View<T, P...>::memory_space,
-          typename Kokkos::View<T, P...>::HostMirror::memory_space>::value &&
-      std::is_same<
-          typename Kokkos::View<T, P...>::data_type,
-          typename Kokkos::View<T, P...>::HostMirror::data_type>::value),
-    typename Kokkos::View<T, P...>::HostMirror>
-create_mirror_view(const Kokkos::View<T, P...>& src) {
-  return Kokkos::create_mirror(src);
-}
-
-template <class T, class... P>
-typename Kokkos::View<T, P...>::HostMirror create_mirror_view(
+auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& src) {
-  return Impl::create_mirror_view(src, view_alloc(wi));
+  return Kokkos::Impl::create_mirror_view(src, view_alloc(wi));
 }
 
-// FIXME_C++17 Improve SFINAE here.
+// space
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
-    const Space&, const Kokkos::View<T, P...>& src,
-    std::enable_if_t<Impl::MirrorViewType<Space, T, P...>::is_same_memspace>* =
-        nullptr) {
-  return src;
+auto create_mirror_view(
+    const Space& space, const Kokkos::View<T, P...>& src) {
+  return Kokkos::Impl::create_mirror_view(src, view_alloc(typename Space::memory_space()));
 }
 
-// FIXME_C++17 Improve SFINAE here.
-template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
-    const Space& space, const Kokkos::View<T, P...>& src,
-    std::enable_if_t<!Impl::MirrorViewType<Space, T, P...>::is_same_memspace>* =
-        nullptr) {
-  return Kokkos::create_mirror(space, src);
-}
-
+//space & without_initializing
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
+auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, Space const&,
     Kokkos::View<T, P...> const& src) {
-  return Impl::create_mirror_view(
+  return Kokkos::Impl::create_mirror_view(
       src, view_alloc(typename Space::memory_space{}, wi));
 }
 
+// view_constructor_args
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
                         const Kokkos::View<T, P...>& src) {
-  return Impl::create_mirror_view(src, arg_prop);
+  return Kokkos::Impl::create_mirror_view(src, arg_prop);
 }
 
 template <class... ViewCtorArgs, class T, class... P>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3557,7 +3557,7 @@ auto create_mirror_view(const Kokkos::View<T, P...>& src,
 
 template <class T, class... P>
 auto create_mirror_view(const Kokkos::View<T, P...>& src) {
-  return src;
+  return Kokkos::Impl::create_mirror_view(src, view_alloc());
 }
 
 // without_initializing

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3425,7 +3425,7 @@ struct MirrorViewType {
   // deep_copy to it.
   using data_type = typename src_view_type::non_const_data_type;
   // The destination view type if it is not the same memory space
-  using dest_view_type = Kokkos::View<data_type, array_layout, Space>;
+  using dest_view_type = Kokkos::View<data_type, array_layout, memory_space>;
   // If it is the same memory_space return the existsing view_type
   // This will also keep the unmanaged trait if necessary
   using view_type =
@@ -3449,7 +3449,7 @@ struct MirrorType {
   // deep_copy to it.
   using data_type = typename src_view_type::non_const_data_type;
   // The destination view type if it is not the same memory space
-  using view_type = Kokkos::View<data_type, array_layout, Space>;
+  using view_type = Kokkos::View<data_type, array_layout, memory_space>;
 };
 
 template <class... ViewCtorArgs>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3470,7 +3470,7 @@ void check_view_ctor_args_create_mirror() {
                 "not explicitly allow padding!");
 }
 
-template <class T, class... P, class... ViewCtorArgs>
+template <class T, class... P, class... ViewCtorArgs, class = std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
 auto create_mirror(const Kokkos::View<T, P...>& src,
                    const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   check_view_ctor_args_create_mirror<ViewCtorArgs...>();
@@ -3491,52 +3491,31 @@ auto create_mirror(const Kokkos::View<T, P...>& src,
 }  // namespace Impl
 
 template <class T, class... P>
-std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
-                 typename Kokkos::View<T, P...>::HostMirror>
-create_mirror(Kokkos::View<T, P...> const& src) {
+auto create_mirror(Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
 template <class T, class... P>
-std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
-                 typename Kokkos::View<T, P...>::HostMirror>
-create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
+auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
               Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(wi));
 }
 
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
-                 typename Impl::MirrorType<Space, T, P...>::view_type>
-create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
+auto create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
 }
 
-template <class T, class... P, class... ViewCtorArgs,
-          typename Enable = std::enable_if_t<
-              std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
-              Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space>>
+template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
                    Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, arg_prop);
 }
 
-template <class T, class... P, class... ViewCtorArgs>
-std::enable_if_t<
-    std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
-        !Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space,
-    typename Kokkos::View<T, P...>::HostMirror>
-create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-              Kokkos::View<T, P...> const& src) {
-  return Impl::create_mirror(src, arg_prop);
-}
-
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
-                 typename Impl::MirrorType<Space, T, P...>::view_type>
-create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
+auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
               Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src,
                              view_alloc(typename Space::memory_space{}, wi));

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3495,24 +3495,28 @@ auto create_mirror(Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
+// without_initializing
 template <class T, class... P>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
               Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(wi));
 }
 
+// space
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
 }
 
+// view_constructor_args
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
                    Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, arg_prop);
 }
 
+// space & without_initializing
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3506,24 +3506,24 @@ auto create_mirror(const Kokkos::View<T, P...>& src,
 template <class T, class... P>
 std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Kokkos::View<T, P...>::HostMirror>
-create_mirror(Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, Impl::ViewCtorProp<>{});
+create_mirror(Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
 template <class T, class... P>
 std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Kokkos::View<T, P...>::HostMirror>
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
-              Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, view_alloc(wi));
+              Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, view_alloc(wi));
 }
 
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Impl::MirrorType<Space, T, P...>::view_type>
-create_mirror(Space const&, Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, view_alloc(typename Space::memory_space{}));
+create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
 }
 
 template <class T, class... P, class... ViewCtorArgs,
@@ -3531,8 +3531,8 @@ template <class T, class... P, class... ViewCtorArgs,
               std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
               Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space>>
 auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-                   Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, arg_prop);
+                   Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, arg_prop);
 }
 
 template <class T, class... P, class... ViewCtorArgs>
@@ -3541,8 +3541,8 @@ std::enable_if_t<
         !Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space,
     typename Kokkos::View<T, P...>::HostMirror>
 create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-              Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, arg_prop);
+              Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, arg_prop);
 }
 
 template <class Space, class T, class... P,
@@ -3550,8 +3550,8 @@ template <class Space, class T, class... P,
 std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Impl::MirrorType<Space, T, P...>::view_type>
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
-              Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror(v, view_alloc(typename Space::memory_space{}, wi));
+              Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}, wi));
 }
 
 namespace Impl {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3647,8 +3647,8 @@ create_mirror_view(const Kokkos::View<T, P...>& src) {
 
 template <class T, class... P>
 typename Kokkos::View<T, P...>::HostMirror create_mirror_view(
-    Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror_view(v, view_alloc(wi));
+    Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& src) {
+  return Impl::create_mirror_view(src, view_alloc(wi));
 }
 
 // FIXME_C++17 Improve SFINAE here.
@@ -3675,15 +3675,15 @@ template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, Space const&,
-    Kokkos::View<T, P...> const& v) {
+    Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(
-      v, view_alloc(typename Space::memory_space{}, wi));
+      src, view_alloc(typename Space::memory_space{}, wi));
 }
 
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
-                        const Kokkos::View<T, P...>& v) {
-  return Impl::create_mirror_view(v, arg_prop);
+                        const Kokkos::View<T, P...>& src) {
+  return Impl::create_mirror_view(src, arg_prop);
 }
 
 template <class... ViewCtorArgs, class T, class... P>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3472,17 +3472,16 @@ void check_view_ctor_args_create_mirror() {
 
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror(const Kokkos::View<T, P...>& src,
-              const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
-
+                   const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   check_view_ctor_args_create_mirror<ViewCtorArgs...>();
 
   auto prop_copy = Impl::with_properties_if_unset(
       arg_prop, std::string(src.label()).append("_mirror"));
 
-  if constexpr (Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space){
+  if constexpr (Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
     using memory_space = typename decltype(prop_copy)::memory_space;
-    using dst_type = typename Impl::MirrorType<memory_space, T,
-                                   P...>::view_type;
+    using dst_type =
+        typename Impl::MirrorType<memory_space, T, P...>::view_type;
     return dst_type(prop_copy, src.layout());
   } else {
     using dst_type = typename View<T, P...>::HostMirror;
@@ -3539,7 +3538,8 @@ std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Impl::MirrorType<Space, T, P...>::view_type>
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
               Kokkos::View<T, P...> const& src) {
-  return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}, wi));
+  return Impl::create_mirror(src,
+                             view_alloc(typename Space::memory_space{}, wi));
 }
 
 namespace Impl {


### PR DESCRIPTION
This PR aims to simplify the code by moving the duplicated intelligence of `create_mirror` and `create_mirror_view` to `Impl::create_mirror` and `Impl::create_mirror_view`. The former functions now behave as a pass-trough that only call their `Impl::` counterpart.

This PR is part of a of a larger effort which aims to fix https://github.com/kokkos/kokkos/issues/6842.