### PR TITLE
Replace SFINAE by `if constexpr`

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3472,17 +3472,16 @@ void check_view_ctor_args_create_mirror() {
 
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror(const Kokkos::View<T, P...>& src,
-              const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
-
+                   const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   check_view_ctor_args_create_mirror<ViewCtorArgs...>();
 
   auto prop_copy = Impl::with_properties_if_unset(
       arg_prop, std::string(src.label()).append("_mirror"));
 
-  if constexpr (Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space){
+  if constexpr (Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
     using memory_space = typename decltype(prop_copy)::memory_space;
-    using dst_type = typename Impl::MirrorType<memory_space, T,
-                                   P...>::view_type;
+    using dst_type =
+        typename Impl::MirrorType<memory_space, T, P...>::view_type;
     return dst_type(prop_copy, src.layout());
   } else {
     using dst_type = typename View<T, P...>::HostMirror;
@@ -3539,7 +3538,8 @@ std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value,
                  typename Impl::MirrorType<Space, T, P...>::view_type>
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
               Kokkos::View<T, P...> const& src) {
-  return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}, wi));
+  return Impl::create_mirror(src,
+                             view_alloc(typename Space::memory_space{}, wi));
 }
 
 namespace Impl {


### PR DESCRIPTION
This PR aims to simplify the code by replacing the multiple overloaded functions of `Impl::create_mirror`, `Impl::create_mirror_view`, and `Impl::create_mirror_view_and_copy` that used SFINAE by one function that uses `if constexpr` instead.

This PR is part of a of a larger effort which aims to fix https://github.com/kokkos/kokkos/issues/6842.